### PR TITLE
feat: Add Flag for Envvar dataType

### DIFF
--- a/.github/workflows/journey-test.yaml
+++ b/.github/workflows/journey-test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup tools used by WaaS
         uses: metro-digital/setup-tools-for-waas@v0.x
         with:
-          version: 'waas/v2alpha1'
+          version: 'waas/v2'
       - uses: actions/setup-go@v2
         with:
           go-version: 1.17

--- a/main/kgcpsecret.go
+++ b/main/kgcpsecret.go
@@ -199,9 +199,7 @@ func createGCPSecretValuesGetter(plugin *KGCPSecret, listGCPSecrets secretsGette
 				return nil, err
 			}
 			if plugin.DataType == "envvar" {
-				envvarString, _ := base64.StdEncoding.DecodeString(value)
-				//fmt.Println(envvarString)
-				envvar, err := godotenv.Unmarshal(string(envvarString))
+				envvar, err := godotenv.Unmarshal(string(value))
 				if err != nil {
 					return nil, fmt.Errorf("error unmarshalling secret %q: %w", key, err)
 				}
@@ -209,7 +207,7 @@ func createGCPSecretValuesGetter(plugin *KGCPSecret, listGCPSecrets secretsGette
 					secrets[k] = base64.StdEncoding.EncodeToString([]byte(v))
 				}
 			} else {
-				secrets[key] = value
+				secrets[key] = base64.StdEncoding.EncodeToString([]byte(value))
 			}
 		}
 
@@ -297,7 +295,8 @@ func getGCPSecretValue(ctx context.Context, client *secretmanager.Client, plugin
 	if err != nil {
 		return "", errors.Wrapf(err, "trouble retrieving secret: %s", name)
 	}
-	value := base64.StdEncoding.EncodeToString(secret.GetPayload().GetData())
+
+	value := string(secret.GetPayload().GetData())
 
 	return value, nil
 }

--- a/main/kgcpsecret.go
+++ b/main/kgcpsecret.go
@@ -199,7 +199,7 @@ func createGCPSecretValuesGetter(plugin *KGCPSecret, listGCPSecrets secretsGette
 				return nil, err
 			}
 			if plugin.DataType == "envvar" {
-				envvar, err := godotenv.Unmarshal(string(value))
+				envvar, err := godotenv.Unmarshal(value)
 				if err != nil {
 					return nil, fmt.Errorf("error unmarshalling secret %q: %w", key, err)
 				}

--- a/main/kgcpsecret.go
+++ b/main/kgcpsecret.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/api/iterator"
 	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 
+	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
@@ -69,6 +70,7 @@ type KGCPSecret struct {
 	Type                  string   `json:"type,omitempty" yaml:"type,omitempty"`
 	Behavior              string   `json:"behavior,omitempty" yaml:"behavior,omitempty"`
 	Keys                  []string `json:"keys,omitempty" yaml:"keys,omitempty"`
+	DataType              string   `json:"dataType,omitempty" yaml:"dataType,omitempty"`
 }
 
 // K8SSecret is a Kubernetes Secret
@@ -196,7 +198,19 @@ func createGCPSecretValuesGetter(plugin *KGCPSecret, listGCPSecrets secretsGette
 			if err != nil {
 				return nil, err
 			}
-			secrets[key] = value
+			if plugin.DataType == "envvar" {
+				envvarString, _ := base64.StdEncoding.DecodeString(value)
+				//fmt.Println(envvarString)
+				envvar, err := godotenv.Unmarshal(string(envvarString))
+				if err != nil {
+					return nil, fmt.Errorf("error unmarshalling secret %q: %w", key, err)
+				}
+				for k, v := range envvar {
+					secrets[k] = base64.StdEncoding.EncodeToString([]byte(v))
+				}
+			} else {
+				secrets[key] = value
+			}
 		}
 
 		return

--- a/main/kgcpsecret_base_test.go
+++ b/main/kgcpsecret_base_test.go
@@ -165,12 +165,12 @@ var _ = Describe("when creating a Kubernetes secret from an KGCPSecret with non 
 		},
 		GCPProjectID:          "cf-2tier-uhd-test-d7",
 		DisableNameSuffixHash: true,
-		Keys: []string{
-			"do-not-exist",
-		},
 	}
 
 	It("should create an error", func() {
+		encryptedSecret.Keys = []string{
+			"do-not-exist",
+		}
 		expected := "error getting 'do-not-exist' secret in Google project 'cf-2tier-uhd-test-d7'. key 'do-not-exist' was not found"
 		_, err := GetSecrets(ctx, nil, &encryptedSecret, getBaseTestKeys, getBaseTestValue)
 

--- a/main/kgcpsecret_postfix_test.go
+++ b/main/kgcpsecret_postfix_test.go
@@ -21,6 +21,7 @@ package main_test
 import (
 	"context"
 	"errors"
+	"encoding/base64"
 
 	. "github.com/metro-digital/kustomize-google-secret-manager/main"
 
@@ -70,14 +71,14 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 		encryptedSecret := createEncryptedGCPSecret(name, key)
 
 		encryptedSecret.Stage = "pp"
-		value := "https://kubernetes-pp.metro.digital"
+		value := base64.StdEncoding.EncodeToString([]byte("https://kubernetes-pp.metro.digital"))
 		expected := createExpectedK8SSecret(name, key, value)
 		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 
 		encryptedSecret.Stage = "prod"
-		value = "https://kubernetes-prod.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("https://kubernetes-prod.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -94,7 +95,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for da
 
 		encryptedSecret.Stage = "prod"
 		encryptedSecret.Dc = "be-gcw1"
-		value := "https://europe.cdn.net"
+		value := base64.StdEncoding.EncodeToString([]byte("https://europe.cdn.net"))
 		expected := createExpectedK8SSecret(name, key, value)
 		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -102,7 +103,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for da
 
 		encryptedSecret.Stage = "prod"
 		encryptedSecret.Dc = "nl-gcw4"
-		value = "https://europe.cdn.net"
+		value = base64.StdEncoding.EncodeToString([]byte("https://europe.cdn.net"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -110,7 +111,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for da
 
 		encryptedSecret.Stage = "prod"
 		encryptedSecret.Dc = "cn-tcs1"
-		value = "https://asia.cdn.net"
+		value = base64.StdEncoding.EncodeToString([]byte("https://asia.cdn.net"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -118,7 +119,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for da
 
 		encryptedSecret.Stage = "prod"
 		encryptedSecret.Dc = "ru-tcm1"
-		value = "https://russia.cdn.net"
+		value = base64.StdEncoding.EncodeToString([]byte("https://russia.cdn.net"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -136,7 +137,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 
 		encryptedSecret.Stage = "pp"
 		encryptedSecret.Dc = "be-gcw1"
-		value := "cassandra-pp.be-gcw1.metro.digital"
+		value := base64.StdEncoding.EncodeToString([]byte("cassandra-pp.be-gcw1.metro.digital"))
 		expected := createExpectedK8SSecret(name, key, value)
 		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -144,7 +145,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 
 		encryptedSecret.Stage = "prod"
 		encryptedSecret.Dc = "be-gcw1"
-		value = "cassandra-prod.be-gcw1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-prod.be-gcw1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -152,7 +153,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 
 		encryptedSecret.Stage = "pp"
 		encryptedSecret.Dc = "nl-gcw4"
-		value = "cassandra-pp.be-gcw1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-pp.be-gcw1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -160,7 +161,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 
 		encryptedSecret.Stage = "prod"
 		encryptedSecret.Dc = "nl-gcw4"
-		value = "cassandra-prod.be-gcw1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-prod.be-gcw1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -168,7 +169,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 
 		encryptedSecret.Stage = "pp"
 		encryptedSecret.Dc = "cn-tcs1"
-		value = "cassandra-pp.cn-tcs1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-pp.cn-tcs1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -176,7 +177,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 
 		encryptedSecret.Stage = "prod"
 		encryptedSecret.Dc = "cn-tcs1"
-		value = "cassandra-prod.cn-tcs1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-prod.cn-tcs1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -184,7 +185,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 
 		encryptedSecret.Stage = "pp"
 		encryptedSecret.Dc = "ru-tcm1"
-		value = "cassandra-pp.ru-tcm1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-pp.ru-tcm1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -192,7 +193,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 
 		encryptedSecret.Stage = "prod"
 		encryptedSecret.Dc = "ru-tcm1"
-		value = "cassandra-prod.ru-tcm1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-prod.ru-tcm1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -210,14 +211,14 @@ var _ = Describe("when creating a Kubernetes secret with different values for en
 
 		encryptedSecret.Environment = "pp"
 		encryptedSecret.Tag = "be-gcw1"
-		value := "https://kubernetes-pp.metro.digital"
+		value := base64.StdEncoding.EncodeToString([]byte("https://kubernetes-pp.metro.digital"))
 		expected := createExpectedK8SSecret(name, key, value)
 		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 
 		encryptedSecret.Environment = "prod"
-		value = "https://kubernetes-prod.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("https://kubernetes-prod.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -234,7 +235,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for ta
 
 		encryptedSecret.Environment = "prod"
 		encryptedSecret.Tag = "be-gcw1"
-		value := "https://europe.cdn.net"
+		value := base64.StdEncoding.EncodeToString([]byte("https://europe.cdn.net"))
 		expected := createExpectedK8SSecret(name, key, value)
 		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -242,7 +243,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for ta
 
 		encryptedSecret.Environment = "prod"
 		encryptedSecret.Tag = "nl-gcw4"
-		value = "https://europe.cdn.net"
+		value = base64.StdEncoding.EncodeToString([]byte("https://europe.cdn.net"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -250,7 +251,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for ta
 
 		encryptedSecret.Environment = "prod"
 		encryptedSecret.Tag = "cn-tcs1"
-		value = "https://asia.cdn.net"
+		value = base64.StdEncoding.EncodeToString([]byte("https://asia.cdn.net"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -258,7 +259,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for ta
 
 		encryptedSecret.Environment = "prod"
 		encryptedSecret.Tag = "ru-tcm1"
-		value = "https://russia.cdn.net"
+		value = base64.StdEncoding.EncodeToString([]byte("https://russia.cdn.net"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -276,7 +277,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for en
 
 		encryptedSecret.Environment = "pp"
 		encryptedSecret.Tag = "be-gcw1"
-		value := "cassandra-pp.be-gcw1.metro.digital"
+		value := base64.StdEncoding.EncodeToString([]byte("cassandra-pp.be-gcw1.metro.digital"))
 		expected := createExpectedK8SSecret(name, key, value)
 		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -284,7 +285,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for en
 
 		encryptedSecret.Environment = "prod"
 		encryptedSecret.Tag = "be-gcw1"
-		value = "cassandra-prod.be-gcw1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-prod.be-gcw1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -292,7 +293,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for en
 
 		encryptedSecret.Environment = "pp"
 		encryptedSecret.Tag = "nl-gcw4"
-		value = "cassandra-pp.be-gcw1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-pp.be-gcw1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -300,7 +301,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for en
 
 		encryptedSecret.Environment = "prod"
 		encryptedSecret.Tag = "nl-gcw4"
-		value = "cassandra-prod.be-gcw1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-prod.be-gcw1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -308,7 +309,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for en
 
 		encryptedSecret.Environment = "pp"
 		encryptedSecret.Tag = "cn-tcs1"
-		value = "cassandra-pp.cn-tcs1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-pp.cn-tcs1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -316,7 +317,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for en
 
 		encryptedSecret.Environment = "prod"
 		encryptedSecret.Tag = "cn-tcs1"
-		value = "cassandra-prod.cn-tcs1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-prod.cn-tcs1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -324,7 +325,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for en
 
 		encryptedSecret.Environment = "pp"
 		encryptedSecret.Tag = "ru-tcm1"
-		value = "cassandra-pp.ru-tcm1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-pp.ru-tcm1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -332,7 +333,7 @@ var _ = Describe("when creating a Kubernetes secret with different values for en
 
 		encryptedSecret.Environment = "prod"
 		encryptedSecret.Tag = "ru-tcm1"
-		value = "cassandra-prod.ru-tcm1.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("cassandra-prod.ru-tcm1.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -349,14 +350,14 @@ var _ = Describe("when creating a Kubernetes secret using environments and stage
 		encryptedSecret.Stage = "xx"
 
 		encryptedSecret.Environment = "pp"
-		value := "https://kubernetes-pp.metro.digital"
+		value := base64.StdEncoding.EncodeToString([]byte("https://kubernetes-pp.metro.digital"))
 		expected := createExpectedK8SSecret(name, key, value)
 		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 
 		encryptedSecret.Environment = "prod"
-		value = "https://kubernetes-prod.metro.digital"
+		value = base64.StdEncoding.EncodeToString([]byte("https://kubernetes-prod.metro.digital"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
@@ -373,14 +374,14 @@ var _ = Describe("when creating a Kubernetes secret using tags and data-centers"
 		encryptedSecret.Dc = "xxx"
 
 		encryptedSecret.Tag = "be-gcw1"
-		value := "https://europe.cdn.net"
+		value := base64.StdEncoding.EncodeToString([]byte("https://europe.cdn.net"))
 		expected := createExpectedK8SSecret(name, key, value)
 		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 
 		encryptedSecret.Tag = "nl-gcw4"
-		value = "https://europe.cdn.net"
+		value = base64.StdEncoding.EncodeToString([]byte("https://europe.cdn.net"))
 		expected = createExpectedK8SSecret(name, key, value)
 		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
 		Expect(err).ToNot(HaveOccurred())

--- a/main/kgcpsecret_prefix_test.go
+++ b/main/kgcpsecret_prefix_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+//go:build unitTests
 // +build unitTests
 
 package main_test
@@ -20,6 +21,7 @@ package main_test
 import (
 	"context"
 	"errors"
+	"encoding/base64"
 
 	. "github.com/metro-digital/kustomize-google-secret-manager/main"
 
@@ -65,7 +67,7 @@ var _ = Describe("when creating a Kubernetes secret", func() {
 	Describe("with a secret manager not containing a secret prefixed with secret name", func() {
 		name := "your-secret"
 		key := "VALUE1"
-		value := "main-VALUE1-value"
+		value := base64.StdEncoding.EncodeToString([]byte("main-VALUE1-value"))
 		encryptedSecret := createEncryptedGCPSecret(name, key)
 		expected := createExpectedK8SSecret(name, key, value)
 
@@ -80,7 +82,7 @@ var _ = Describe("when creating a Kubernetes secret", func() {
 	Describe("with a secret manager containing a secret prefixed with secret name", func() {
 		name := "my-secret"
 		key := "VALUE1"
-		value := "my-secret-VALUE1-value"
+		value := base64.StdEncoding.EncodeToString([]byte("my-secret-VALUE1-value"))
 		encryptedSecret := createEncryptedGCPSecret(name, key)
 		expected := createExpectedK8SSecret(name, key, value)
 
@@ -95,7 +97,7 @@ var _ = Describe("when creating a Kubernetes secret", func() {
 	Describe("with a secret manager containing a secret prefixed with namespace name", func() {
 		name := "my-secret"
 		key := "VALUE2"
-		value := "my-namespace-VALUE2-value"
+		value := base64.StdEncoding.EncodeToString([]byte("my-namespace-VALUE2-value"))
 		encryptedSecret := createEncryptedGCPSecret(name, key)
 		encryptedSecret.Namespace = "my-namespace"
 		expected := createExpectedK8SSecret(name, key, value)
@@ -112,7 +114,7 @@ var _ = Describe("when creating a Kubernetes secret", func() {
 	Describe("with a secret manager containing a secret prefixed with namespace and secret name", func() {
 		name := "my-secret"
 		key := "VALUE3"
-		value := "my-namespace-and-secret-VALUE3-value"
+		value := base64.StdEncoding.EncodeToString([]byte("my-namespace-and-secret-VALUE3-value"))
 		encryptedSecret := createEncryptedGCPSecret(name, key)
 		encryptedSecret.Namespace = "my-namespace"
 		expected := createExpectedK8SSecret(name, key, value)
@@ -132,7 +134,7 @@ var _ = Describe("when creating a Kubernetes secret of type 'dockercfg'", func()
 	It("should use the correspondig data value for every secret", func() {
 		name := "dockercfg1"
 		key := "data"
-		value := "my-dockercfg1-data-value"
+		value := base64.StdEncoding.EncodeToString([]byte("my-dockercfg1-data-value"))
 		encryptedSecret := createEncryptedGCPSecret(name, key)
 		expected := createExpectedK8SSecret(name, key, value)
 
@@ -143,7 +145,7 @@ var _ = Describe("when creating a Kubernetes secret of type 'dockercfg'", func()
 
 		name = "dockercfg2"
 		key = "data"
-		value = "my-dockercfg2-data-value"
+		value = base64.StdEncoding.EncodeToString([]byte("my-dockercfg2-data-value"))
 		encryptedSecret = createEncryptedGCPSecret(name, key)
 		expected = createExpectedK8SSecret(name, key, value)
 

--- a/main/kgcpsecret_utils_test.go
+++ b/main/kgcpsecret_utils_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+//go:build unitTests
 // +build unitTests
 
 package main_test
@@ -43,6 +44,7 @@ func createEncryptedGCPSecret(name string, secretKey string) KGCPSecret {
 		DisableNameSuffixHash: true,
 		Type:                  "",
 		Behavior:              "",
+		DataType:              "",
 		Keys: []string{
 			secretKey,
 		},


### PR DESCRIPTION
This PR will add a dataType flag, where this flag allows you to create a Kubernetes secret with data in the form of an environment variable, so you can directly use the secret as an environment variable in your deployment.
To be able to use this flag, make sure the data in the google secret manager has the format ENV=VAL.