### PR TITLE
Disable cgo on pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o=./release/KGCPSecret ./main/ 
           tar -C ./release -cvzf ./release/KGCPSecret.darwin.amd64.tar.gz ./KGCPSecret ./LICENSE ./LICENSES
           GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o=./release/KGCPSecret ./main/ 
-          tar -C ./release -cvzf ./release/KGCPSecret.darwin.amd64.tar.gz ./KGCPSecret ./LICENSE ./LICENSES
+          tar -C ./release -cvzf ./release/KGCPSecret.darwin.arm.tar.gz ./KGCPSecret ./LICENSE ./LICENSES
           GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -o=./release/KGCPSecret ./main/ 
           tar -C ./release -cvzf ./release/KGCPSecret.windows.386.tar.gz ./KGCPSecret ./LICENSE ./LICENSES
       - uses: actions/setup-node@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,13 @@ jobs:
       - run: |
           go mod tidy
           cp LICENSE ./release
-          GOOS=linux GOARCH=amd64 go build -o=./release/KGCPSecret ./main/ 
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o=./release/KGCPSecret ./main/ 
           tar -C ./release -cvzf ./release/KGCPSecret.linux.amd64.tar.gz ./KGCPSecret ./LICENSE ./LICENSES
-          GOOS=darwin GOARCH=amd64 go build -o=./release/KGCPSecret ./main/ 
+          GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o=./release/KGCPSecret ./main/ 
           tar -C ./release -cvzf ./release/KGCPSecret.darwin.amd64.tar.gz ./KGCPSecret ./LICENSE ./LICENSES
-          GOOS=windows GOARCH=386 go build -o=./release/KGCPSecret ./main/ 
+          GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o=./release/KGCPSecret ./main/ 
+          tar -C ./release -cvzf ./release/KGCPSecret.darwin.amd64.tar.gz ./KGCPSecret ./LICENSE ./LICENSES
+          GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -o=./release/KGCPSecret ./main/ 
           tar -C ./release -cvzf ./release/KGCPSecret.windows.386.tar.gz ./KGCPSecret ./LICENSE ./LICENSES
       - uses: actions/setup-node@v2
         with:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ make build
 
 * LINUX AMD64 (tested)
 * MAC AMD64 (only cross compiled)
+* MAC ARM64 (only cross compiled)
 * Windows 386 (only cross compiled)
 
 ## Copyright and License


### PR DESCRIPTION
Disable CGO to release binary as static, to make it easier to distribute
also, add arm64 binary artifact on every release.